### PR TITLE
Improve battle view with correct attacks, descriptions, and logging

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -230,17 +230,7 @@ if (state.opp.passives.has('Metallschild')) state.opp.mods.dmgTakenFlatMinus += 
 const logEl = document.getElementById('log');
 function logLine({who='sys', text='', cls=''}){
   state.log.push({who, text, cls});
-  const div = document.createElement('div');
-  div.className = `it ${cls}`;
-  const tag = document.createElement('span');
-  tag.className = `tag ${who==='me'?'me':who==='opp'?'opp':'sys'}`;
-  tag.textContent = who==='me' ? '[ME]' : who==='opp' ? '[OPP]' : '[SYS]';
-  div.appendChild(tag);
-  const span = document.createElement('span');
-  span.innerHTML = text;
-  div.appendChild(span);
-  logEl.appendChild(div);
-  logEl.scrollTop = logEl.scrollHeight;
+  renderLog();
 }
 function renderLog(){
   logEl.innerHTML='';
@@ -506,32 +496,27 @@ const ATK_DESC = {
   'Monsterangriff': 'Standardangriff des Monsters.',
   'Schwertschlag': '100 Schaden.',
   'Verrat': '80 Schaden.',
-  'Sicherer Schlag': '90 Schaden. Schaden nicht veränderbar.',
-  'Geheime Mission': '90 Schaden. Nicht konterbar.',
-  'Sichere und geheime Mission': '60 Schaden. Nicht konterbar. Schaden nicht veränderbar.',
+  'Sicherer Schlag': '90 Schaden, nicht modifizierbar.',
+  'Geheime Mission': '90 Schaden, nicht konterbar.',
+  'Sichere und geheime Mission': '60 Schaden, nicht konterbar oder modifizierbar.',
   'Heilung': 'Heile 100 Leben.',
-  'Über dem Horizont': 'Erhalte 120 Leben (erhöht maximale Leben).',
-  'Wut': 'Deine nächste Schaden-Attacke verursacht +20 Schaden.',
-  'Vorbereitung': 'Deine nächste Schaden-Attacke verursacht +30 Schaden.',
-  'Feurige Waffen': 'Erhalte in diesem Zug 10 Wut.',
+  'Über dem Horizont': 'Erhalte 120 Leben (Max-LP).',
+  'Wut': 'Nächste Schadensattacke +20.',
+  'Vorbereitung': 'Nächste Schadensattacke +30.',
+  'Feurige Waffen': 'Erhalte 10 Wut in diesem Zug.',
   'Hartes Training': 'Erhalte 10 Wut.',
   'Messerstich': '20 Schaden.',
   'Messerwürfe': '4×20 Schaden.',
   'Letzter Wille': '5×20 Schaden.',
   'Finale': '150 Schaden.',
-  'Seelenschlag': '120 Schaden. Du erleidest 50 Selbstschaden.',
-  'Gleichheit': 'Setze die Leben des Gegners auf deine aktuellen Leben.',
-  'Langsam, aber sicher': '10 × (Anzahl deiner erfolgreich ausgeführten Attacken) Schaden.',
-  'Lehren': 'Verleihe einem Charakter die Attacke: „100 Schaden“.',
-  'Lehren: 100 Schaden': '100 Schaden.',
-  'Geschenk des Lebens': 'Verleihe allen freundlichen Monstern +50 Leben.',
-  'Lebender Schild': 'Wähle ein freundliches Monster. Verleihe ihm Spott.',
-  'Opfer': 'Vernichte ein freundliches Monster. Verbündete erhalten seine Leben.',
+  'Seelenschlag': '120 Schaden, du selbst erleidest 50 Schaden.',
+  'Gleichheit': 'Setzt gegnerische Leben auf deine Leben.',
+  'Opfer': 'Vernichte ein verbündetes Monster; Verbündete erhalten seine Leben.',
   'Freund der Tiere': 'Beschwöre ein 50/50 Monster.',
   'Karnickel': 'Beschwöre drei 0/10 Monster.',
   'Lebender Baum': 'Beschwöre ein 0/150 Monster.',
-  'Wand': 'Beschwöre ein 0/10 Monster mit Spott. Es kann nicht angreifen.',
-  'Feuerkobold': 'Beschwöre ein 0/50 Monster mit: Bei Beschwörung 50 Schaden an ein Ziel.'
+  'Wand': 'Beschwöre ein 0/10 Monster mit Spott, das nicht angreifen kann.',
+  'Feuerkobold': 'Beschwöre ein 0/50 Monster; bei Beschwörung 50 Schaden an ein Ziel.'
 };
 
 function getAttackDesc(name){
@@ -628,7 +613,7 @@ function applyFromShared(payload, v){
   state.opp = inflateUnit(remote.me); state.opp.id='opp';
   state.myMonsters = remote.oppMonsters.map(inflateUnit);
   state.oppMonsters = remote.myMonsters.map(inflateUnit);
-  state.log = (remote.log||[]).map(e=>({ ...e, who: e.who==='me'?'opp':e.who==='opp'?'me':e.who }));
+  state.log = (remote.log||[]).map(e=>({ who: e.who==='me'?'opp': e.who==='opp'?'me':'sys', text:e.text, cls:e.cls }));
 
   renderAll();
 }

--- a/battle.html
+++ b/battle.html
@@ -210,14 +210,15 @@ let idSeq = 1; const newId = () => `id_${idSeq++}`;
 const state = {
   version: 0,
   priority: gs.life?.starter === 'me' ? 'me' : 'opp',
-  me: { id:'me', name: gs.myId || 'Du', hp: meStart, maxHp: meStart, rage: 0, nextDamageBonus: 0,
+  me: { id:'me', name: (gs.myId || 'Du').split('-')[0], hp: meStart, maxHp: meStart, rage: 0, nextDamageBonus: 0,
         passives: new Set(gs.passives?.me || []), knownAttacks: new Set(myKnownAttacks), mods:{ dmgTakenFlatMinus:0 } },
-  opp:{ id:'opp', name: gs.oppId || 'Gegner', hp: oppStart, maxHp: oppStartBase, rage:0, nextDamageBonus:0,
-        passives: new Set(gs.passives?.opp || []), knownAttacks: new Set(gs.passives?.opp || []), mods:{ dmgTakenFlatMinus:0 } },
+  opp:{ id:'opp', name: (gs.oppId || 'Gegner').split('-')[0], hp: oppStart, maxHp: oppStartBase, rage:0, nextDamageBonus:0,
+        passives: new Set(gs.passives?.opp || []), knownAttacks: new Set(), mods:{ dmgTakenFlatMinus:0 } },
   myMonsters: [],
   oppMonsters: [],
   locks: {}, // z.B. Attack-Locks (Wachsames Auge)
-  selection: { actor:null, action:null, target:null }
+  selection: { actor:null, action:null, target:null },
+  log: []
 };
 
 if (state.me.passives.has('Metallschild')) state.me.mods.dmgTakenFlatMinus += 10;
@@ -228,6 +229,7 @@ if (state.opp.passives.has('Metallschild')) state.opp.mods.dmgTakenFlatMinus += 
  *************************/
 const logEl = document.getElementById('log');
 function logLine({who='sys', text='', cls=''}){
+  state.log.push({who, text, cls});
   const div = document.createElement('div');
   div.className = `it ${cls}`;
   const tag = document.createElement('span');
@@ -238,6 +240,22 @@ function logLine({who='sys', text='', cls=''}){
   span.innerHTML = text;
   div.appendChild(span);
   logEl.appendChild(div);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+function renderLog(){
+  logEl.innerHTML='';
+  state.log.forEach(entry=>{
+    const div=document.createElement('div');
+    div.className=`it ${entry.cls||''}`;
+    const tag=document.createElement('span');
+    tag.className=`tag ${entry.who==='me'?'me':entry.who==='opp'?'opp':'sys'}`;
+    tag.textContent=entry.who==='me'?'[ME]':entry.who==='opp'?'[OPP]':'[SYS]';
+    div.appendChild(tag);
+    const span=document.createElement('span');
+    span.innerHTML=entry.text;
+    div.appendChild(span);
+    logEl.appendChild(div);
+  });
   logEl.scrollTop = logEl.scrollHeight;
 }
 function logDamage(who, fromName, toName, amt){ logLine({who, text:`<span class="dmg">-${amt} HP</span> ${toName} durch <b>${fromName}</b>.`}); }
@@ -307,41 +325,41 @@ function renderActions(){
   else{
     selInfo.textContent = `Ausgewählt: ${actor.side==='me'?'[ME]':'[OPP]'} ${actor.name}`;
 
-    if(actor.side==='me'){
-      // Hauptcharakter → eigene bekannten Attacken + generische
+    if(actor.id==='me'){
       actions = [...state.me.knownAttacks];
-    } else if(actor.side==='opp'){
-      // Gegner: nur Anzeige (read-only)
-      actions = [...state.opp.knownAttacks];
+    } else if(actor.id==='opp'){
+      actions = [...state.opp.passives].map(p=>`${p} (Passiv)`).concat([...state.opp.knownAttacks]);
       readOnly=true;
     } else {
-      // Monster: Standardangriff, falls ATK>0 und kann angreifen
       if(actor.atk>0 && actor.canAttack!==false){ actions.push(`Monsterangriff (${actor.atk})`); }
-      // evtl. eigene bekannte Attacken des Monsters
+      if(actor.passives) actions = actions.concat([...actor.passives].map(p=>`${p} (Passiv)`));
       if(actor.knownAttacks) actions = actions.concat([...actor.knownAttacks]);
+      if(actor.side==='opp') readOnly=true;
     }
   }
 
   atkList.innerHTML='';
   actions.forEach(a=>{
     const row=document.createElement('div'); row.className='atk';
-    const left=document.createElement('div'); left.innerHTML = `<b>${a}</b>`;
+    const left=document.createElement('div');
+    const desc=getAttackDesc(a);
+    left.innerHTML = `<b>${a}</b>${desc?`<div class=\"small\">${desc}</div>`:''}`;
     const right=document.createElement('div');
     if(!readOnly && isOwn(actor?.id)){
       const btn=document.createElement('button'); btn.textContent='Wählen';
       btn.onclick=()=>{ state.selection.action=a; renderActions(); renderPriority(); };
       right.appendChild(btn);
     } else {
-      right.innerHTML = `<span class="small muted">Nur Anzeige</span>`;
+      right.innerHTML = `<span class=\"small muted\">Nur Anzeige</span>`;
     }
     row.appendChild(left); row.appendChild(right);
     if(state.selection.action===a){ row.style.outline='2px solid #2563eb'; }
     atkList.appendChild(row);
   });
-  if(actions.length===0){ atkList.innerHTML = `<div class="small">Für diese Einheit sind noch keine Attacken bekannt.</div>`; }
+  if(actions.length===0){ atkList.innerHTML = `<div class=\"small\">Für diese Einheit sind noch keine Attacken bekannt.</div>`; }
 }
 
-function renderAll(){ renderHpBars(); renderUnits(); renderActions(); renderPriority(); }
+function renderAll(){ renderHpBars(); renderUnits(); renderActions(); renderPriority(); renderLog(); }
 
 /*************************
  *  SELECTION            *
@@ -385,37 +403,48 @@ function refUnit(id){
 }
 function clampHp(u){ u.hp = Math.max(0, Math.min(u.hp, u.maxHp)); }
 
+function getSide(id){
+  if(id==='me' || state.myMonsters.some(m=>m.id===id)) return 'me';
+  if(id==='opp' || state.oppMonsters.some(m=>m.id===id)) return 'opp';
+  return 'me';
+}
+
+function recordKnownAttack(actorId, name){
+  const r = refUnit(actorId); if(!r) return;
+  r.knownAttacks = r.knownAttacks || new Set();
+  r.knownAttacks.add(name);
+}
+
 /*************************
  *  ENGINE               *
  *************************/
 const Engine = {
-  damage({srcId, tgtId, base, modifiable=true, label='Attacke'}){
+  damage({srcId, tgtId, base, modifiable=true, label='Attacke', consume=true}){
     const src = refUnit(srcId), tgt = refUnit(tgtId);
     if(!src || !tgt) return;
     let dmg = base;
     if (modifiable) {
       const bonus = (src.nextDamageBonus||0) + (src.rage||0);
       dmg += bonus;
-      src.nextDamageBonus = 0; // verbrauchen
-      src.rage = 0;
+      if(consume){ src.nextDamageBonus = 0; src.rage = 0; }
       const red = (tgt.mods?.dmgTakenFlatMinus||0);
       dmg = Math.max(0, dmg - red);
     }
     tgt.hp -= dmg; clampHp(tgt);
-    logDamage(src.side||'me', label, tgt.name||tgt.id, dmg);
+    logDamage(getSide(srcId), label, tgt.name||tgt.id, dmg);
   },
-  heal({tgtId, amount}){ const t = refUnit(tgtId); if(!t) return; const before=t.hp; t.hp=Math.min(t.maxHp,t.hp+amount); logHeal(t.side||'me', t.name||t.id, t.hp-before); },
-  gainLife({tgtId, amount}){ const t=refUnit(tgtId); if(!t) return; t.maxHp+=amount; t.hp+=amount; logGainLife(t.side||'me', t.name||t.id, amount); },
-  addNextDamageBonus({srcId, amount, label}){ const s=refUnit(srcId); if(!s) return; s.nextDamageBonus=(s.nextDamageBonus||0)+amount; logLine({who:s.side||'me', text:`${label||'Bonus'}: +${amount} auf nächste Schadensattacke.`}); },
-  addRage({srcId, amount}){ const s=refUnit(srcId); if(!s) return; s.rage=(s.rage||0)+amount; logLine({who:s.side||'me', text:`Wut +${amount}.`}); },
+  heal({tgtId, amount}){ const t = refUnit(tgtId); if(!t) return; const before=t.hp; t.hp=Math.min(t.maxHp,t.hp+amount); logHeal(getSide(tgtId), t.name||t.id, t.hp-before); },
+  gainLife({tgtId, amount}){ const t=refUnit(tgtId); if(!t) return; t.maxHp+=amount; t.hp+=amount; logGainLife(getSide(tgtId), t.name||t.id, amount); },
+  addNextDamageBonus({srcId, amount, label}){ const s=refUnit(srcId); if(!s) return; s.nextDamageBonus=(s.nextDamageBonus||0)+amount; logLine({who:getSide(srcId), text:`${label||'Bonus'}: +${amount} auf nächste Schadensattacke.`}); },
+  addRage({srcId, amount}){ const s=refUnit(srcId); if(!s) return; s.rage=(s.rage||0)+amount; logLine({who:getSide(srcId), text:`Wut +${amount}.`}); },
   summon({side,name,hp,maxHp,atk=0,taunt=false,canAttack=true,onSummonDamage=0}){
     const u = { id:newId(), name, hp:hp??maxHp, maxHp:maxHp??hp, atk, taunt, canAttack, knownAttacks:new Set() };
     if(side==='me') state.myMonsters.push(u); else state.oppMonsters.push(u);
     logLine({ who: side, text:`beschwört <b>${name}</b> (${atk}/${u.maxHp}${taunt?' mit Spott':''}).`});
     if(onSummonDamage>0){ const targetId = side==='me' ? state.opp.id : state.me.id; Engine.damage({srcId:u.id, tgtId:targetId, base:onSummonDamage, label:`${name} (Beschwörung)`}); }
   },
-  grantTaunt({tgtId}){ const t=refUnit(tgtId); if(!t) return; t.taunt = true; logLine({who:t.side||'me', text:`<b>${t.name}</b> erhält Spott.`}); },
-  grantAttack100({tgtId}){ const t=refUnit(tgtId); if(!t) return; t.knownAttacks = t.knownAttacks || new Set(); t.knownAttacks.add('Lehren: 100 Schaden'); logLine({who:t.side||'me', text:`<b>${t.name}</b> lernt: „100 Schaden“.`}); },
+  grantTaunt({tgtId}){ const t=refUnit(tgtId); if(!t) return; t.taunt = true; logLine({who:getSide(tgtId), text:`<b>${t.name}</b> erhält Spott.`}); },
+  grantAttack100({tgtId}){ const t=refUnit(tgtId); if(!t) return; t.knownAttacks = t.knownAttacks || new Set(); t.knownAttacks.add('Lehren: 100 Schaden'); logLine({who:getSide(tgtId), text:`<b>${t.name}</b> lernt: „100 Schaden“.`}); },
   giveAlliedMonstersLife({side, amount}){
     const arr = side==='me' ? state.myMonsters : state.oppMonsters;
     arr.forEach(m=>{ m.maxHp += amount; m.hp += amount; });
@@ -451,8 +480,8 @@ const ATK = {
   'Feurige Waffen': { needsTarget:false, run: ({actorId})=>Engine.addRage({srcId:actorId,amount:10}) },
   'Hartes Training': { needsTarget:false, run: ({actorId})=>Engine.addRage({srcId:actorId,amount:10}) },
   'Messerstich': { needsTarget:true, run: ({actorId,targetId})=>Engine.damage({srcId:actorId,tgtId:targetId,base:20,modifiable:true,label:'Messerstich'}) },
-  'Messerwürfe': { needsTarget:true, run: ({actorId,targetId})=>{ for(let i=0;i<4;i++) Engine.damage({srcId:actorId,tgtId:targetId,base:20,modifiable:true,label:'Messerwürfe'}); } },
-  'Letzter Wille': { needsTarget:true, run: ({actorId,targetId})=>{ for(let i=0;i<5;i++) Engine.damage({srcId:actorId,tgtId:targetId,base:20,modifiable:true,label:'Letzter Wille'}); } },
+  'Messerwürfe': { needsTarget:true, run: ({actorId,targetId})=>{ for(let i=0;i<4;i++) Engine.damage({srcId:actorId,tgtId:targetId,base:20,modifiable:true,label:'Messerwürfe',consume:i===3}); } },
+  'Letzter Wille': { needsTarget:true, run: ({actorId,targetId})=>{ for(let i=0;i<5;i++) Engine.damage({srcId:actorId,tgtId:targetId,base:20,modifiable:true,label:'Letzter Wille',consume:i===4}); } },
   'Finale': { needsTarget:true, run: ({actorId,targetId})=>Engine.damage({srcId:actorId,tgtId:targetId,base:150,modifiable:true,label:'Finale'}) },
   'Seelenschlag': { needsTarget:true, run: ({actorId,targetId})=>{ Engine.damage({srcId:actorId,tgtId:targetId,base:120,modifiable:true,label:'Seelenschlag'}); Engine.damage({srcId:actorId,tgtId:actorId,base:50,modifiable:false,label:'Selbstschaden'}); } },
   'Gleichheit': { needsTarget:false, run: ({actorId})=>{ const enemy = actorId==='me'? state.opp : state.me; const me = actorId==='me'? state.me : state.opp; enemy.hp = Math.min(enemy.maxHp, me.hp); logLine({who: (actorId==='me'?'me':'opp'), text:`Gleicht die gegnerischen Leben auf ${enemy.hp} an.`}); } },
@@ -472,6 +501,43 @@ const ATK = {
   'Wand': { needsTarget:false, run: ({actorId})=>{ const side = actorId==='me'?'me':'opp'; Engine.summon({side,name:'Wand',hp:10,maxHp:10,atk:0,taunt:true,canAttack:false}); } },
   'Feuerkobold': { needsTarget:false, run: ({actorId})=>{ const side = actorId==='me'?'me':'opp'; Engine.summon({side,name:'Feuerkobold',hp:50,maxHp:50,atk:0,onSummonDamage:50}); } }
 };
+
+const ATK_DESC = {
+  'Monsterangriff': 'Standardangriff des Monsters.',
+  'Schwertschlag': '100 Schaden.',
+  'Verrat': '80 Schaden.',
+  'Sicherer Schlag': '90 Schaden. Schaden nicht veränderbar.',
+  'Geheime Mission': '90 Schaden. Nicht konterbar.',
+  'Sichere und geheime Mission': '60 Schaden. Nicht konterbar. Schaden nicht veränderbar.',
+  'Heilung': 'Heile 100 Leben.',
+  'Über dem Horizont': 'Erhalte 120 Leben (erhöht maximale Leben).',
+  'Wut': 'Deine nächste Schaden-Attacke verursacht +20 Schaden.',
+  'Vorbereitung': 'Deine nächste Schaden-Attacke verursacht +30 Schaden.',
+  'Feurige Waffen': 'Erhalte in diesem Zug 10 Wut.',
+  'Hartes Training': 'Erhalte 10 Wut.',
+  'Messerstich': '20 Schaden.',
+  'Messerwürfe': '4×20 Schaden.',
+  'Letzter Wille': '5×20 Schaden.',
+  'Finale': '150 Schaden.',
+  'Seelenschlag': '120 Schaden. Du erleidest 50 Selbstschaden.',
+  'Gleichheit': 'Setze die Leben des Gegners auf deine aktuellen Leben.',
+  'Langsam, aber sicher': '10 × (Anzahl deiner erfolgreich ausgeführten Attacken) Schaden.',
+  'Lehren': 'Verleihe einem Charakter die Attacke: „100 Schaden“.',
+  'Lehren: 100 Schaden': '100 Schaden.',
+  'Geschenk des Lebens': 'Verleihe allen freundlichen Monstern +50 Leben.',
+  'Lebender Schild': 'Wähle ein freundliches Monster. Verleihe ihm Spott.',
+  'Opfer': 'Vernichte ein freundliches Monster. Verbündete erhalten seine Leben.',
+  'Freund der Tiere': 'Beschwöre ein 50/50 Monster.',
+  'Karnickel': 'Beschwöre drei 0/10 Monster.',
+  'Lebender Baum': 'Beschwöre ein 0/150 Monster.',
+  'Wand': 'Beschwöre ein 0/10 Monster mit Spott. Es kann nicht angreifen.',
+  'Feuerkobold': 'Beschwöre ein 0/50 Monster mit: Bei Beschwörung 50 Schaden an ein Ziel.'
+};
+
+function getAttackDesc(name){
+  const base = name.replace(/ \(.*\)$/,'');
+  return ATK_DESC[base] || '';
+}
 
 /*************************
  *  ACTION FLOW          *
@@ -495,6 +561,7 @@ commitBtn.addEventListener('click', ()=>{
     logLine({who:'me', text:`setzt <b>${actionName}</b> ein${targetId?` → <i>${getUnit(targetId)?.name||targetId}</i>`:''}.`});
   }catch(e){ warn('Fehler bei Attacke: '+(e?.message||e)); return; }
 
+  recordKnownAttack(actor.id, actionName);
   postActionCleanup(actor.id, actionName);
   // Sync: Speichere gesamten State (Serialisierung von Sets!)
   saveSharedState(serializeState());
@@ -541,7 +608,8 @@ function serializeState(){
     priority: state.priority,
     me: to(state.me), opp: to(state.opp),
     myMonsters: state.myMonsters.map(to),
-    oppMonsters: state.oppMonsters.map(to)
+    oppMonsters: state.oppMonsters.map(to),
+    log: state.log
   };
 }
 
@@ -556,10 +624,11 @@ function applyFromShared(payload, v){
   state.priority = (remote.priority==='me' ? 'opp' : 'me'); // Sicht drehen
 
   // Seiten tauschen (damit dieser Client weiterhin "me" ist)
-  state.me = inflateUnit(remote.opp);
-  state.opp = inflateUnit(remote.me);
+  state.me = inflateUnit(remote.opp); state.me.id='me';
+  state.opp = inflateUnit(remote.me); state.opp.id='opp';
   state.myMonsters = remote.oppMonsters.map(inflateUnit);
   state.oppMonsters = remote.myMonsters.map(inflateUnit);
+  state.log = (remote.log||[]).map(e=>({ ...e, who: e.who==='me'?'opp':e.who==='opp'?'me':e.who }));
 
   renderAll();
 }

--- a/index.html
+++ b/index.html
@@ -427,6 +427,8 @@ function saveGameStateAndGo() {
   const key = `osja_game_${roomCode || 'default'}`;
   sessionStorage.setItem(key, JSON.stringify(state));
 
+  localStorage.removeItem(`osja_room_${roomCode || 'default'}`);
+
   // --- NEU: Markiere "ich wechsle" & sag dem Gegner Bescheid
   switchingToBattle = true;
   try {


### PR DESCRIPTION
## Summary
- Correctly tag log entries and sync attacker/defender names
- Show opponent passives and known attacks while keeping own actions selectable
- Apply damage bonuses to each hit and reset room state before a new battle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f12cfed2083269bc4ff1cbdc0e679